### PR TITLE
Implement import declarations

### DIFF
--- a/docs/language-reference/imports.md
+++ b/docs/language-reference/imports.md
@@ -1,0 +1,59 @@
+# Import Statements
+
+(for Luvascript Version 0.1)
+
+### Importing a package
+
+    import <package-name>;
+
+### Only importing some functions or variables
+
+    import <package-name>::<identifier>;
+
+or
+
+    import <package-name>::{ 
+        <identifier>, 
+        <other identifier>,
+        ...
+    };
+
+!!! example
+
+        import std.io::write;
+        import std.io::read;
+        import std.io::print;
+        import std.io::println;
+        import std.io::readln;
+        import std.io::flush;
+
+    or
+
+        import std.io::{
+            write,
+            read,
+            print,
+            println,
+            readln,
+            flush
+        };
+
+### Importing all functions and variables from a package
+
+    import <package-name>::*;
+
+!!! example
+
+        import std.io::*;
+
+### Importing a package and renaming it
+
+    import <package-name> as <new-package-name>;
+
+### Importing functions and variables from a package and renaming them
+
+    import <package-name>::{
+        <type/variable-identifer> as <new-type/variable-identifer>, 
+        <other-type/variable-identifer> as <other-new-type/variable-identifer>,
+        ...
+    };

--- a/docs/language-reference/index.md
+++ b/docs/language-reference/index.md
@@ -4,3 +4,4 @@
 * [Datatypes](./datatypes.md)
 * [External Functions](./external-functions.md)
 * [Inline Assembly](./inline-assembly.md)
+* [Import Statements](./imports.md)

--- a/inc/scope_impl.h
+++ b/inc/scope_impl.h
@@ -1,5 +1,6 @@
 #include <scope.h>
 
+#include <options.h>
 #include <util/arraylist.h>
 
 #include <types/ast.h>
@@ -10,9 +11,11 @@
 /**
  * @brief 
  * 
+ * @param options 
  * @param ast 
+ * @return int 
  */
-int scope_evaluate_ast(AST *ast, ArrayList *modules);
+int scope_evaluate_ast(CommandlineOptions *options, AST *ast);
 
 /**
  * @brief 

--- a/inc/types/import.h
+++ b/inc/types/import.h
@@ -1,11 +1,47 @@
 #ifndef __LUVA_IMPORT_H__
 #define __LUVA_IMPORT_H__
 
-typedef struct {
-	char *package_name;
-	char *type_identifier;
-} import_stmt_t;
+#include <util/arraylist.h>
 
-void import_stmt_free(import_stmt_t *stmt);
+typedef struct _ImportDeclaration ImportDeclaration;
+
+/**
+ * @brief 
+ * 
+ */
+struct _ImportDeclaration {
+	ArrayList *package_names; 		// ArrayList<String>
+	ArrayList *type_identifiers; 	// ArrayList<String>
+};
+
+/**
+ * @brief 
+ * 
+ * @return ImportDeclaration* 
+ */
+ImportDeclaration *import_declaration_new();
+
+/**
+ * @brief 
+ * 
+ * @param import_declaration 
+ * @return ImportDeclaration* 
+ */
+ImportDeclaration *import_declaration_copy(ImportDeclaration *import_declaration);
+
+/**
+ * @brief 
+ * 
+ * @param import_declarations 
+ * @return ArrayList* 
+ */
+ArrayList *compact_import_declarations(ArrayList *import_declarations);
+
+/**
+ * @brief 
+ * 
+ * @param import_declaration 
+ */
+void import_declaration_free(ImportDeclaration *import_declaration);
 
 #endif // __LUVA_IMPORT_H__

--- a/inc/types/import.h
+++ b/inc/types/import.h
@@ -2,6 +2,7 @@
 #define __LUVA_IMPORT_H__
 
 #include <util/arraylist.h>
+#include <stdbool.h>
 
 typedef struct _ImportDeclaration ImportDeclaration;
 
@@ -11,6 +12,7 @@ typedef struct _ImportDeclaration ImportDeclaration;
  */
 struct _ImportDeclaration {
 	ArrayList *package_names; 		// ArrayList<String>
+	char *package_name;				// String
 	ArrayList *type_identifiers; 	// ArrayList<String>
 };
 
@@ -36,6 +38,22 @@ ImportDeclaration *import_declaration_copy(ImportDeclaration *import_declaration
  * @return ArrayList* 
  */
 ArrayList *compact_import_declarations(ArrayList *import_declarations);
+
+/**
+ * @brief 
+ * 
+ * @param import_declaration 
+ * @return true 
+ */
+bool import_declaration_should_import_all(ImportDeclaration *import_declaration);
+
+/**
+ * @brief 
+ * 
+ * @param type_ident 
+ * @return true  
+ */
+bool import_declaration_contains(ImportDeclaration *import_declaration, char *type_ident);
 
 /**
  * @brief 

--- a/inc/types/package.h
+++ b/inc/types/package.h
@@ -9,9 +9,10 @@ typedef struct package Package;
 struct package {
 	char *name;
 
+	char *file_path;
 	// ArrayList *imported_packages;
 
-	ArrayList *import_stmts;
+	ArrayList *import_declarations;
 
 	Scope *package_scope;
 	ArrayList *functions;

--- a/inc/util/file.h
+++ b/inc/util/file.h
@@ -1,6 +1,12 @@
 #ifndef LUVA_FILE_H
 #define LUVA_FILE_H
 
+#ifndef _DEFAULT_SOURCE
+    // This is required the `realpath` function
+    // used in `to_absolute_path`
+	#define _DEFAULT_SOURCE
+#endif
+
 #include <util/arraylist.h>
 
 char *read_file(const char* path);
@@ -10,5 +16,8 @@ int file_remove(const char* path);
 ArrayList *list_files(const char *dir);
 ArrayList *list_dirs(const char *directory);
 const char *get_filename_extension(const char *filename);
+char *to_absolute_path(const char *path);
+char *get_absolute_dirname(const char *file);
+char *path_combine(const char *path, const char *file);
 
 #endif // LUVA_FILE_H

--- a/inc/util/file.h
+++ b/inc/util/file.h
@@ -17,7 +17,7 @@ ArrayList *list_files(const char *dir);
 ArrayList *list_dirs(const char *directory);
 const char *get_filename_extension(const char *filename);
 char *to_absolute_path(const char *path);
-char *get_absolute_dirname(const char *file);
+char *get_absolute_dirname_from_file(const char *file);
 char *path_combine(const char *path, const char *file);
 
 #endif // LUVA_FILE_H

--- a/lib/io.lv
+++ b/lib/io.lv
@@ -1,33 +1,32 @@
 package io;
 
-function print_number(number: int): int {
+function print_number(number: i64): void {
 	asm {
-		mov		eax, edi				; function arg
-		mov		ecx, 0xa				; base 10
+		mov		rax, rdi				; function arg
+		mov		rcx, 0xa				; base 10
 		push	rcx						; ASCII newline '\n' = 0xa = base
 		mov		rsi, rsp
 		sub		rsp, 16					; not needed on 64-bit Linux, the red-zone is big enough.  Change the LEA below if you remove this.
 										; rsi is pointing at '\n' on the stack, with 16B of "allocated" space below that.
 	.toascii_digit:						; do 
-		xor		edx, edx
-		div		ecx						; edx=remainder = low digit = 0..9.  eax/=10
+		xor		rdx, rdx
+		div		rcx						; edx=remainder = low digit = 0..9.  eax/=10
 										;; DIV IS SLOW.  use a multiplicative inverse if performance is relevant.
-		add		edx, '0'
+		add		rdx, '0'
 		dec		rsi						; store digits in MSD-first printing order, working backwards from the end of the string
 		mov		[rsi], dl
-		test	eax, eax				;  while(x);
+		test	rax, rax				;  while(x);
 		jnz		.toascii_digit
 										; rsi points to the first digit
-		mov		eax, 1					; __NR_write from /usr/include/asm/unistd_64.h
-		mov		edi, 1					; fd = STDOUT_FILENO
+		mov		rax, 1					; __NR_write from /usr/include/asm/unistd_64.h
+		mov		rdi, 1					; fd = STDOUT_FILENO
 		; pointer already in RSI		; buf = last digit stored = most significant
-		lea		edx, [rsp + 16 + 1]		; yes, it's safe to truncate pointers before subtracting to find length.
-		sub		edx, esi				; RDX = length = end-start, including the \n
+		lea		rdx, [rsp + 16 + 1]		; yes, it's safe to truncate pointers before subtracting to find length.
+		sub		rdx, rsi				; RDX = length = end-start, including the \n
 		syscall							; write(1, string /*RSI*/,  digits + 1)
 
 		add		rsp, 24					; (in 32-bit: add esp,20) undo the push and the buffer reservation
 	}
-	return 0;
 }
 
 // TODO: implement this function

--- a/lib/math.lv
+++ b/lib/math.lv
@@ -1,10 +1,10 @@
 package math;
 
-function sqrt(n: int): int {
+function sqrt(n: i64): i64 {
 	if (n < 0) return -1;
 	if (n == 0) return 0;
-	var x: int = n;
-	var y: int = 1;
+	var x: i64 = n;
+	var y: i64 = 1;
 	while (x > y) {
 		x = (x + y) / 2;
 		y = n / x;
@@ -12,22 +12,22 @@ function sqrt(n: int): int {
 	return x;
 }
 
-//function abs(n: int): int {
+//function abs(n: i64): i64 {
 //	if (n < 0) return -n;
 //	return n;
 //}
 
-function min(a: int, b: int): int {
+function min(a: i64, b: i64): i64 {
 	if (a < b) return a;
 	return b;
 }
 
-function max(a: int, b: int): int {
+function max(a: i64, b: i64): i64 {
 	if (a > b) return a;
 	return b;
 }
 
-function pow(a: int, b: int): int {
+function pow(a: i64, b: i64): i64 {
 	if (b == 0) return 1;
 	if (b == 1) return a;
 	if (b % 2 == 0) return pow(a * a, b / 2);

--- a/lib/util.lv
+++ b/lib/util.lv
@@ -1,13 +1,13 @@
 package util;
 
-from math import sqrt;
+import math::sqrt;
 
-function isPrime(n: int): bool {
+function isPrime(n: i64): bool {
 	if (n <= 1)
 		return false;
 		
-	var index: int = 2;
-	var upperBound: int = sqrt(n) + 1;
+	var index: i64 = 2;
+	var upperBound: i64 = sqrt(n) + 1;
 
 	while(index < upperBound) {
 		if (n % index == 0) {

--- a/makefile
+++ b/makefile
@@ -3,45 +3,84 @@ INC_DIR		:= inc
 OBJ_DIR		:= obj
 BIN_DIR		:= bin
 
+SOURCES		:= $(shell find $(SRC_DIR) -name '*.c')
+OBJECTS		:= $(subst $(SRC_DIR)/,$(OBJ_DIR)/,$(SOURCES:.c=.o))
+
 BIN_NAME	:= lvc
 
-TARGET		:= $(BIN_DIR)/$(BIN_NAME)
+# paths and filenames for 'make debug'
+DEBUG_OBJ_DIR	:= $(OBJ_DIR)/debug
+DEBUG_BIN_DIR	:= $(BIN_DIR)/debug
 
-SOURCES		:= $(wildcard $(SRC_DIR)/*.c $(SRC_DIR)/*/*.c $(SRC_DIR)/*/*/*.c)
-OBJECTS		:= $(subst src/,obj/,$(SOURCES:.c=.o))
-INC_DIRS	:= -I$(INC_DIR)# $(addprefix -I,$(dir $(wildcard $(INC_DIR)/*/.)))
+DEBUG_OBJECTS	:= $(subst $(SRC_DIR)/,$(DEBUG_OBJ_DIR)/,$(SOURCES:.c=.o))
+DEBUG_TARGET	:= $(DEBUG_BIN_DIR)/$(BIN_NAME)
+
+# paths and filenames for 'make release'
+RELEASE_OBJ_DIR	:= $(OBJ_DIR)/release
+RELEASE_BIN_DIR	:= $(BIN_DIR)/release
+
+RELEASE_OBJECTS	:= $(subst $(SRC_DIR)/,$(RELEASE_OBJ_DIR)/,$(SOURCES:.c=.o))
+RELEASE_TARGET	:= $(RELEASE_BIN_DIR)/$(BIN_NAME)
+
+# ------------------------------------
 
 CC			:= gcc
-CFLAGS		:= -g -c -std=c17 -Wall -Werror
+CFLAGS		:= -c -std=c17 -Wall -Werror -I$(INC_DIR)#-Wextra
 LDFLAGS		:= -g
 
 # ------------------------------------
 
-all: build
+all: debug release
 
-build: dirs $(TARGET)
-
-rebuild: clean build
-
-test: build
-	@python3 test.py
-
-dirs:
+mkdirs:
 	@mkdir -p $(OBJ_DIR)
 	@mkdir -p $(BIN_DIR)
+	@mkdir -p $(DEBUG_OBJ_DIR)
+	@mkdir -p $(DEBUG_BIN_DIR)
+	@mkdir -p $(RELEASE_OBJ_DIR)
+	@mkdir -p $(RELEASE_BIN_DIR)
 
-install: build
-	mv $(TARGET) /usr/bin/$(BIN_NAME)
+debug: CFLAGS += -DDEBUG
+debug: mkdirs debug_build
+
+release: CFLAGS += -O3
+release: mkdirs release_build
+
+test: debug
+	@python3 test.py
+
+install: release
+	cp $(RELEASE_TARGET) /usr/bin/$(BIN_NAME)
 
 uninstall:
 	rm /usr/bin/$(BIN_NAME)
 
-$(OBJECTS): obj/%.o : src/%.c
+clean: debug_clean release_clean
+
+# --------- [Debug Targets] ----------
+
+debug_build: $(DEBUG_TARGET)
+
+$(DEBUG_OBJECTS): $(DEBUG_OBJ_DIR)/%.o : $(SRC_DIR)/%.c
 	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) $(INC_DIRS) $< -o $@
 
-$(TARGET): $(OBJECTS)
+$(DEBUG_TARGET): $(DEBUG_OBJECTS)
 	$(CC) $(LDFLAGS) $^ -o $@
 
-clean:
-	rm -rf $(OBJECTS) $(TARGET)
+debug_clean:
+	rm -rf $(DEBUG_OBJECTS) $(DEBUG_TARGET)
+
+# -------- [Release Targets] ---------
+
+release_build: $(RELEASE_TARGET)
+
+$(RELEASE_OBJECTS): $(RELEASE_OBJ_DIR)/%.o : $(SRC_DIR)/%.c
+	@mkdir -p $(@D)
+	$(CC) $(CFLAGS) $(INC_DIRS) $< -o $@
+
+$(RELEASE_TARGET): $(RELEASE_OBJECTS)
+	$(CC) $(LDFLAGS) $^ -o $@
+
+release_clean:
+	rm -rf $(RELEASE_OBJECTS) $(RELEASE_TARGET)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
     - Datatypes: language-reference/datatypes.md
     - External Functions: language-reference/external-functions.md
     - Inline Assembly: language-reference/inline-assembly.md
+    - Import Statements: language-reference/imports.md
   - Language Specifications:
     - Overview: language-specifications/index.md
     - Version 0.1.0: language-specifications/0.1.0.md

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -28,15 +28,14 @@ void compile(const char *assembly_code, CommandlineOptions *options)
 
 	char *obj_filename = NULL;
 	
-	if (options->output_file_name != NULL) {
-		obj_filename = strdup(options->output_file_name);
+	if (options->link == true) {
+		obj_filename = stradd(options->output_file_name, ".o");
 	} else {
-		stradd(options->output_file_name, ".o");
+		obj_filename = strdup(options->output_file_name);
 	}
-	
 
 	compile_to_object_file(asm_filename, obj_filename);
-	
+
 	if (options->link)
 	{
 		if (options->is_shared_library)

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -26,7 +26,14 @@ void compile(const char *assembly_code, CommandlineOptions *options)
 		return;
 	}
 
-	char *obj_filename = stradd(options->output_file_name, ".o");
+	char *obj_filename = NULL;
+	
+	if (options->output_file_name != NULL) {
+		obj_filename = strdup(options->output_file_name);
+	} else {
+		stradd(options->output_file_name, ".o");
+	}
+	
 
 	compile_to_object_file(asm_filename, obj_filename);
 	

--- a/src/compiler/x86-64/compiler.c
+++ b/src/compiler/x86-64/compiler.c
@@ -218,7 +218,6 @@ char *compile_global_variable(Variable *glob_var) {
 	strcpy(asm_code, var_lcc_identifier);
 	strcat(asm_code, ":");
 
-	free(var_lcc_identifier);
 
 	switch (glob_var->type->size) {
 		case 1: // BYTE
@@ -238,6 +237,9 @@ char *compile_global_variable(Variable *glob_var) {
 			exit(1);
 	}
 
+	asm_code = straddall(asm_code, "global ", var_lcc_identifier, "\n", NULL);
+
+	free(var_lcc_identifier);
 	free(variable_value);
 
 	return asm_code;

--- a/src/main.c
+++ b/src/main.c
@@ -79,6 +79,7 @@ int main(int argc, char **argv)
 			ast_free(ast);
 			return -1;
 		}
+		package->file_path = to_absolute_path(source_file_name);
 
 		arraylist_add(ast->packages, package);
 

--- a/src/main.c
+++ b/src/main.c
@@ -92,15 +92,15 @@ int main(int argc, char **argv)
 	}
 
 	// load global modules
-	ArrayList *modules = arraylist_create();
-	if (!options->nostdlib)
-	{
-		// struct module *std_module = module_load(GLOBAL_LIBRARY_DIR "std");
-		// arraylist_add(modules, std_module);
-	}
+	// ArrayList *modules = arraylist_create();
+	// if (!options->nostdlib)
+	// {
+	// 	// struct module *std_module = module_load(GLOBAL_LIBRARY_DIR "std");
+	// 	// arraylist_add(modules, std_module);
+	// }
 
 	// evaluate the scopes of the packages
-	if (scope_evaluate_ast(ast, modules) != 0) {
+	if (scope_evaluate_ast(options, ast) != 0) {
 		// free allocated memory
 		options_free(options);
 		ast_free(ast);

--- a/src/scope.c
+++ b/src/scope.c
@@ -70,12 +70,13 @@ int scope_evaluate_ast(AST *ast, ArrayList *modules) {
 					Package *local_pkg = arraylist_get(local_pkgs, i);
 
 					// compare package names
-					if (strcmp(local_pkg->name, arraylist_get(import_decl->package_names, 0)) == 0) {
+					if (strcmp(local_pkg->name, import_decl->package_name) == 0) {
 						
 						package_found = true;
 						/// if the import declaration is empty, then we need to import all
-						if (arraylist_size(pkg->import_declarations) == 0) {
-							log_warning("importing all from package %s\n", local_pkg->name);
+						// if (arraylist_size(import_decl->type_identifiers) == 0) {
+						if (import_declaration_contains(import_decl, "*")) {
+							// log_warning("importing all from package %s\n", local_pkg->name);
 									// add the function to the package
 							for (size_t l = 0; l < arraylist_size(local_pkg->extern_functions); l++) {
 								FunctionTemplate *extern_func_template = arraylist_get(local_pkg->extern_functions, l);
@@ -103,7 +104,7 @@ int scope_evaluate_ast(AST *ast, ArrayList *modules) {
 						for (size_t k = 0; k < arraylist_size(import_decl->type_identifiers); k++) {
 							char *type_identifier = arraylist_get(import_decl->type_identifiers, k);
 
-							log_warning("importing type %s from package %s\n", type_identifier, local_pkg->name);
+							// log_warning("importing type %s from package %s\n", type_identifier, local_pkg->name);
 							// check if the type identifier is in local_pkg
 
 							// first check extern functions

--- a/src/typechecker.c
+++ b/src/typechecker.c
@@ -534,7 +534,8 @@ Datatype *type_of_literal_expression(const Literal_T *literal, Scope *scope) {
 		}
 		case LITERAL_IDENTIFIER: {
 			if (!scope_contains_variable(scope, literal->value)) {
-				log_error("Variable %s is not defined\n", literal->value);
+				printf("%s:%d:%d: " IRED "error: " RESET "variable '%s' is not defined\n",
+						"TODO", 0, 0, literal->value);
 				return NULL;
 			}
 

--- a/src/types/function.c
+++ b/src/types/function.c
@@ -6,15 +6,15 @@
 
 FunctionTemplate *convert_to_function_template(Function *func) {
 	FunctionTemplate *func_template = calloc(1, sizeof(FunctionTemplate));
-	func_template->identifier = func->identifier;
-	func_template->return_type = func->return_type;
+	func_template->identifier = strdup(func->identifier);
+	func_template->return_type = copy_datatype(func->return_type);
 	func_template->param_datatypes = arraylist_create();
 
 	// convert function parameters to variable templates
 	for (size_t j = 0; j < func->parameters->size; j++) {
 		Variable *param = arraylist_get(func->parameters, j);
 		// VariableTemplate *var_template = convert_to_variable_template(param);
-		arraylist_add(func_template->param_datatypes, param->type);
+		arraylist_add(func_template->param_datatypes, copy_datatype(param->type));
 	}
 	return func_template;
 }

--- a/src/types/import.c
+++ b/src/types/import.c
@@ -11,12 +11,15 @@
 ImportDeclaration *import_declaration_new() {
     ImportDeclaration *import_declaration = (ImportDeclaration *) malloc(sizeof(ImportDeclaration));
     import_declaration->package_names = arraylist_create();
+    import_declaration->package_name = NULL;
     import_declaration->type_identifiers = arraylist_create();
     return import_declaration;
 }
 
 ImportDeclaration *import_declaration_copy(ImportDeclaration *import_declaration) {
     ImportDeclaration *new_import_declaration = import_declaration_new();
+
+    new_import_declaration->package_name = strdup(import_declaration->package_name);
 
     for (size_t i = 0; i < arraylist_size(import_declaration->package_names); i++) {
         arraylist_add(new_import_declaration->package_names, arraylist_get(import_declaration->package_names, i));
@@ -32,55 +35,129 @@ ImportDeclaration *import_declaration_copy(ImportDeclaration *import_declaration
 ArrayList *compact_import_declarations(ArrayList *import_declarations) {
     ArrayList *compacted_import_declarations = arraylist_create();
 
+    bool successful_evaluation = true;
+
     for (size_t i = 0; i < arraylist_size(import_declarations); i++) {
         ImportDeclaration *import_declaration = (ImportDeclaration *) arraylist_get(import_declarations, i);
 
-        // check if compacted_import_declarations already contains an import with the same package name
-        bool already_contains_import = false;
-        ImportDeclaration *current = NULL;
-        for (size_t j = 0; j < arraylist_size(compacted_import_declarations); j++) {
-            ImportDeclaration *compacted_import_declaration = (ImportDeclaration *) arraylist_get(compacted_import_declarations, j);
+        // check if `compact_import_declarations` already
+        // contains an import_declaration with the same package_names
 
-            // TODO: check whole package name
-            if (strcmp(arraylist_get(import_declaration->package_names, 0), arraylist_get(compacted_import_declaration->package_names, 0)) == 0) {
-                already_contains_import = true;
-                current = compacted_import_declaration;
+        bool compacted_already_contains_package = false;
+
+        ImportDeclaration *compacted_import_declaration = NULL;
+        for (size_t j = 0; j < arraylist_size(compacted_import_declarations); j++) {
+            compacted_import_declaration = (ImportDeclaration *) arraylist_get(compacted_import_declarations, j);
+
+            if (strcmp(import_declaration->package_name, compacted_import_declaration->package_name) == 0) {
+                compacted_already_contains_package = true;
                 break;
             }
         }
 
-        if (already_contains_import) {
-            // add type identifiers to existing import
-            for (size_t j = 0; j < arraylist_size(import_declaration->type_identifiers); j++) {
-                char *type_identifier = arraylist_get(import_declaration->type_identifiers, j);
+        if (compacted_already_contains_package) {
+            // we found an import_declaration with the same package_names
 
-                /// `*` is a special case, it means all types in the
-                /// package (e.g. `ìmport std.io::*;`) should be imported
-                /// 
-                /// the compiler knows that is should import all types if
-                /// `current->type_identifiers` is empty
-                if (strcmp(type_identifier, "*") == 0) {
-                    // free all type identifiers from `current`
-                    for (size_t k = 0; k < arraylist_size(current->type_identifiers); k++) {
-                        char *type_identifier = arraylist_get(current->type_identifiers, k);
-                        free(type_identifier);
-                    }
+            if (import_declaration_contains(compacted_import_declaration, "*")) {
+                printf("%s:%d:%d: " RED "error: " RESET "cannot import types after using wildcard import '*' for the same package '%s'\n",
+                        "TODO", 0, 0, import_declaration->package_name);
+                successful_evaluation = false;
+                
+                goto _exit;
+            }
 
-                    // clear arraylist (size = 0)
-                    arraylist_clear(current->type_identifiers);
-                } else {
-                    arraylist_add(current->type_identifiers, strdup(type_identifier));
+            if (import_declaration_contains(import_declaration, "*")) {
+                if (arraylist_size(compacted_import_declaration->type_identifiers) > 0) {
+                    printf("%s:%d:%d: " RED "error: " RESET "cannot use wildcard import '*' after importing types from the same package '%s'\n",
+                            "TODO", 0, 0, import_declaration->package_name);
+                    successful_evaluation = false;
+                    
+                    goto _exit;
                 }
             }
-        } else {
-            // add the import declaration to `compacted_import_declarations`
-            arraylist_add(compacted_import_declarations, import_declaration_copy(import_declaration));
+
+            // check if types are already imported
+            for (size_t j = 0; j < arraylist_size(import_declaration->type_identifiers); j++) {
+                char *type_ident = (char *) arraylist_get(import_declaration->type_identifiers, j);
+
+                if (import_declaration_contains(compacted_import_declaration, type_ident)) {
+                    printf("%s:%d:%d: " RED "error: " RESET "cannot import type '%s' twice from for the same package '%s'\n",
+                            "TODO", 0, 0, type_ident, import_declaration->package_name);
+                    successful_evaluation = false;
+
+                    goto _exit;
+                }
+
+                arraylist_add(compacted_import_declaration->type_identifiers, strdup(type_ident));
+            }
+
+            continue;
+        } // else: we did not find an import_declaration with the same package_names
+
+        // we didn't find a package_name match, so we can add the import_declaration
+        if (import_declaration_contains(import_declaration, "*")) {
+            // we found an import_declaration with the wildcard `*`
+
+            // check if import_declaration contains additional type_identifiers
+            if (arraylist_size(import_declaration->type_identifiers) > 1) {
+                printf("%s:%d:%d: " YELLOW "warning: " RESET "import_declaration contains additional type_identifiers after wildcard '*'\n",
+                       "TODO", 0, 0);
+            }
+        } // else: we found an import_declaration without the wildcard `*`
+
+        // add it to the compacted_import_declarations
+        arraylist_add(compacted_import_declarations, import_declaration_copy(import_declaration));
+    }
+
+    _exit: ;
+
+    // print all imported types
+    for (size_t i = 0; i < arraylist_size(compacted_import_declarations); i++) {
+        ImportDeclaration *import_declaration = (ImportDeclaration *) arraylist_get(compacted_import_declarations, i);
+
+        printf("%s:%d:%d: " GREEN "info: " RESET "imported types from package '%s':\n",
+                "TODO", 0, 0, import_declaration->package_name);
+
+        for (size_t j = 0; j < arraylist_size(import_declaration->type_identifiers); j++) {
+            char *type_ident = (char *) arraylist_get(import_declaration->type_identifiers, j);
+            printf("%s:%d:%d: " GREEN "info: " RESET "  - %s\n",
+                    "TODO", 0, 0, type_ident);
         }
     }
 
-    log_warning("compacted %zu to %zu imports\n", arraylist_size(import_declarations), arraylist_size(compacted_import_declarations));
+    // TODO: if successful_evaluation == false, we should free all allocated memory
+    
+    return successful_evaluation ? compacted_import_declarations : NULL;
+}
 
-    return compacted_import_declarations;
+bool import_declaration_should_import_all(ImportDeclaration *import_declaration) {
+    if (arraylist_size(import_declaration->type_identifiers) == 0) {
+        return true;
+    }
+
+    for (size_t i = 0; i < arraylist_size(import_declaration->type_identifiers); i++) {
+        char *type_identifier = arraylist_get(import_declaration->type_identifiers, i);
+        if (strcmp(type_identifier, "*") == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool import_declaration_contains(ImportDeclaration *import_declaration, char *type_ident) {
+    if (import_declaration == NULL || import_declaration->type_identifiers == NULL) {
+        return false;
+    }
+    
+    for (size_t i = 0; i < arraylist_size(import_declaration->type_identifiers); i++) {
+        char *type_identifier = arraylist_get(import_declaration->type_identifiers, i);
+        if (strcmp(type_identifier, type_ident) == 0) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 void import_declaration_free(ImportDeclaration *import_declaration) {

--- a/src/types/import.c
+++ b/src/types/import.c
@@ -112,18 +112,18 @@ ArrayList *compact_import_declarations(ArrayList *import_declarations) {
     _exit: ;
 
     // print all imported types
-    for (size_t i = 0; i < arraylist_size(compacted_import_declarations); i++) {
-        ImportDeclaration *import_declaration = (ImportDeclaration *) arraylist_get(compacted_import_declarations, i);
+    // for (size_t i = 0; i < arraylist_size(compacted_import_declarations); i++) {
+    //     ImportDeclaration *import_declaration = (ImportDeclaration *) arraylist_get(compacted_import_declarations, i);
 
-        printf("%s:%d:%d: " GREEN "info: " RESET "imported types from package '%s':\n",
-                "TODO", 0, 0, import_declaration->package_name);
+    //     printf("%s:%d:%d: " GREEN "info: " RESET "imported types from package '%s':\n",
+    //             "TODO", 0, 0, import_declaration->package_name);
 
-        for (size_t j = 0; j < arraylist_size(import_declaration->type_identifiers); j++) {
-            char *type_ident = (char *) arraylist_get(import_declaration->type_identifiers, j);
-            printf("%s:%d:%d: " GREEN "info: " RESET "  - %s\n",
-                    "TODO", 0, 0, type_ident);
-        }
-    }
+    //     for (size_t j = 0; j < arraylist_size(import_declaration->type_identifiers); j++) {
+    //         char *type_ident = (char *) arraylist_get(import_declaration->type_identifiers, j);
+    //         printf("%s:%d:%d: " GREEN "info: " RESET "  - %s\n",
+    //                 "TODO", 0, 0, type_ident);
+    //     }
+    // }
 
     // TODO: if successful_evaluation == false, we should free all allocated memory
     

--- a/src/types/import.c
+++ b/src/types/import.c
@@ -1,0 +1,93 @@
+#include <types/import.h>
+
+#include <string.h>
+#include <stdbool.h>
+
+#include <util/util.h>
+#include <util/arraylist.h>
+
+#include <logging/logger.h>
+
+ImportDeclaration *import_declaration_new() {
+    ImportDeclaration *import_declaration = (ImportDeclaration *) malloc(sizeof(ImportDeclaration));
+    import_declaration->package_names = arraylist_create();
+    import_declaration->type_identifiers = arraylist_create();
+    return import_declaration;
+}
+
+ImportDeclaration *import_declaration_copy(ImportDeclaration *import_declaration) {
+    ImportDeclaration *new_import_declaration = import_declaration_new();
+
+    for (size_t i = 0; i < arraylist_size(import_declaration->package_names); i++) {
+        arraylist_add(new_import_declaration->package_names, arraylist_get(import_declaration->package_names, i));
+    }
+
+    for (size_t i = 0; i < arraylist_size(import_declaration->type_identifiers); i++) {
+        arraylist_add(new_import_declaration->type_identifiers, arraylist_get(import_declaration->type_identifiers, i));
+    }
+
+    return new_import_declaration;
+}
+
+ArrayList *compact_import_declarations(ArrayList *import_declarations) {
+    ArrayList *compacted_import_declarations = arraylist_create();
+
+    for (size_t i = 0; i < arraylist_size(import_declarations); i++) {
+        ImportDeclaration *import_declaration = (ImportDeclaration *) arraylist_get(import_declarations, i);
+
+        // check if compacted_import_declarations already contains an import with the same package name
+        bool already_contains_import = false;
+        ImportDeclaration *current = NULL;
+        for (size_t j = 0; j < arraylist_size(compacted_import_declarations); j++) {
+            ImportDeclaration *compacted_import_declaration = (ImportDeclaration *) arraylist_get(compacted_import_declarations, j);
+
+            // TODO: check whole package name
+            if (strcmp(arraylist_get(import_declaration->package_names, 0), arraylist_get(compacted_import_declaration->package_names, 0)) == 0) {
+                already_contains_import = true;
+                current = compacted_import_declaration;
+                break;
+            }
+        }
+
+        if (already_contains_import) {
+            // add type identifiers to existing import
+            for (size_t j = 0; j < arraylist_size(import_declaration->type_identifiers); j++) {
+                char *type_identifier = arraylist_get(import_declaration->type_identifiers, j);
+
+                /// `*` is a special case, it means all types in the
+                /// package (e.g. `ìmport std.io::*;`) should be imported
+                /// 
+                /// the compiler knows that is should import all types if
+                /// `current->type_identifiers` is empty
+                if (strcmp(type_identifier, "*") == 0) {
+                    // free all type identifiers from `current`
+                    for (size_t k = 0; k < arraylist_size(current->type_identifiers); k++) {
+                        char *type_identifier = arraylist_get(current->type_identifiers, k);
+                        free(type_identifier);
+                    }
+
+                    // clear arraylist (size = 0)
+                    arraylist_clear(current->type_identifiers);
+                } else {
+                    arraylist_add(current->type_identifiers, strdup(type_identifier));
+                }
+            }
+        } else {
+            // add the import declaration to `compacted_import_declarations`
+            arraylist_add(compacted_import_declarations, import_declaration_copy(import_declaration));
+        }
+    }
+
+    log_warning("compacted %zu to %zu imports\n", arraylist_size(import_declarations), arraylist_size(compacted_import_declarations));
+
+    return compacted_import_declarations;
+}
+
+void import_declaration_free(ImportDeclaration *import_declaration) {
+    if (import_declaration == NULL) {
+        return;
+    }
+    arraylist_free(import_declaration->package_names);
+    arraylist_free(import_declaration->type_identifiers);
+    free(import_declaration);
+}

--- a/src/types/package.c
+++ b/src/types/package.c
@@ -6,20 +6,22 @@
 
 Package *package_new() {
 	Package *package = malloc(sizeof(Package));
+	package->name = NULL;
+	package->file_path = NULL;
 	package->extern_functions = arraylist_create();
 	package->functions = arraylist_create();
 	package->global_variables = arraylist_create();
-	package->import_stmts = arraylist_create();
+	package->import_declarations = arraylist_create();
 	package->imported_functions = arraylist_create();
 	package->imported_global_variables = arraylist_create();
-	// package->package_scope = scope_new();
+	package->package_scope = NULL;
 	return package;
 }
 
 void package_merge(Package *dest, Package *src) {
 	arraylist_addall(dest->functions, src->functions);
 	arraylist_addall(dest->global_variables, src->global_variables);
-	arraylist_addall(dest->import_stmts, src->import_stmts);
+	arraylist_addall(dest->import_declarations, src->import_declarations);
 	arraylist_addall(dest->imported_functions, src->imported_functions);
 	arraylist_addall(dest->imported_global_variables, src->imported_global_variables);
 	scope_merge(dest->package_scope, src->package_scope);

--- a/src/types/types_free.c
+++ b/src/types/types_free.c
@@ -136,12 +136,10 @@ void package_free(Package *package) {
 	free(package->file_path);
 	scope_free(package->package_scope);
 
-
-	// for (size_t i = 0; i < package->imported_packages->size; i++) {
-	// 	Package *imported_package = arraylist_get(package->imported_packages, i);
-	// 	package_free(imported_package);
-	// }
-
+	for (size_t i = 0; i < package->import_declarations->size; i++) {
+		ImportDeclaration *import_declaration = arraylist_get(package->import_declarations, i);
+		import_declaration_free(import_declaration);
+	}
 
 	if (package->functions != NULL) {
 		for (size_t i = 0; i < package->functions->size; i++) {

--- a/src/types/types_free.c
+++ b/src/types/types_free.c
@@ -133,6 +133,7 @@ void package_free(Package *package) {
 		return;
 	}
 	free(package->name);
+	free(package->file_path);
 	scope_free(package->package_scope);
 
 
@@ -140,6 +141,7 @@ void package_free(Package *package) {
 	// 	Package *imported_package = arraylist_get(package->imported_packages, i);
 	// 	package_free(imported_package);
 	// }
+
 
 	if (package->functions != NULL) {
 		for (size_t i = 0; i < package->functions->size; i++) {
@@ -158,17 +160,23 @@ void package_free(Package *package) {
 		Variable *variable = arraylist_get(package->global_variables, i);
 		variable_free(variable);
 	}
+
+	// free imported functions and variables
+	for (size_t i = 0; i < package->imported_functions->size; i++) {
+		FunctionTemplate *function = arraylist_get(package->imported_functions, i);
+		function_template_free(function);
+	}
+
+	for (size_t i = 0; i < package->imported_global_variables->size; i++) {
+		VariableTemplate *variable = arraylist_get(package->imported_global_variables, i);
+		variable_template_free(variable);
+	}
 }
 
 void options_free(CommandlineOptions *options) {
+	if (options == NULL) return;
 	free(options->input_file_name);
 	free(options->output_file_name);
 	arraylist_free(options->library_paths);
 	free(options);
-}
-
-void import_stmt_free(import_stmt_t *import_stmt) {
-	free(import_stmt->package_name);
-	free(import_stmt->type_identifier);
-	free(import_stmt);
 }

--- a/src/types/variable.c
+++ b/src/types/variable.c
@@ -12,8 +12,8 @@
 VariableTemplate *convert_to_variable_template(Variable *variable) {
 	VariableTemplate *template = calloc(1, sizeof(VariableTemplate));
 
-	template->identifier = variable->identifier->value;
-	template->datatype = variable->type;
+	template->identifier = strdup(variable->identifier->value);
+	template->datatype = copy_datatype(variable->type);
 	template->is_constant = variable->is_constant;
 
 	return template;

--- a/src/util/arraylist.c
+++ b/src/util/arraylist.c
@@ -125,6 +125,7 @@ ArrayList *arraylist_copy(ArrayList *src) {
 
 void arraylist_clear(ArrayList *arr) {
     arr->size = 0;
+    arr->capacity = INITIAL_BASE_ARRAY_SIZE;
     free(arr->data);
     arr->data = NULL;
 }

--- a/src/util/io/file.c
+++ b/src/util/io/file.c
@@ -99,7 +99,7 @@ char *to_absolute_path(const char *path) {
 	return realpath(path, NULL);
 }
 
-char *get_absolute_dirname(const char *file) {
+char *get_absolute_dirname_from_file(const char *file) {
 	return dirname(to_absolute_path(file));
 }
 

--- a/src/util/io/file.c
+++ b/src/util/io/file.c
@@ -3,7 +3,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
+#include <limits.h>
+#include <libgen.h>
 #include <dirent.h>
 
 #include <util/arraylist.h>
@@ -92,4 +93,21 @@ const char *get_filename_extension(const char *filename) {
 	const char *dot = strrchr(filename, '.');
 	if(!dot || dot == filename) return "";
 	return dot + 1;
+}
+
+char *to_absolute_path(const char *path) {
+	return realpath(path, NULL);
+}
+
+char *get_absolute_dirname(const char *file) {
+	return dirname(to_absolute_path(file));
+}
+
+char *path_combine(const char *path, const char *file) {
+	size_t len = strlen(path) + strlen(file) + 2;
+	char *combined = (char*) malloc(sizeof(char) * len);
+	strcpy(combined, path);
+	strcat(combined, "/");
+	strcat(combined, file);
+	return combined;
 }

--- a/src/util/io/logger.c
+++ b/src/util/io/logger.c
@@ -58,6 +58,8 @@ void log_error(const char *message, ...) {
 void log_debug(const char *message, ...) {
     // printf("[DEBUG]: %s", message);
     /* Declare a va_list type variable */
+    #if defined DEBUG
+
     va_list args;
 
     /* Initialise the va_list variable with the ... after message */
@@ -68,11 +70,15 @@ void log_debug(const char *message, ...) {
 
     /* Clean up the va_list */
     va_end(args);
+
+    #endif
 }
 
 void log_cmd(const char *message, ...) {
     // printf("[CMD]: %s", command);
     /* Declare a va_list type variable */
+    #if defined DEBUG
+
     va_list args;
 
     /* Initialise the va_list variable with the ... after message */
@@ -83,4 +89,6 @@ void log_cmd(const char *message, ...) {
 
     /* Clean up the va_list */
     va_end(args);
+
+    #endif
 }

--- a/src/util/options.c
+++ b/src/util/options.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include <util/util.h>
+#include <util/file.h>
 #include <logging/logger.h>
 
 // default filename of the generated binary file if no output filename is specified
@@ -61,6 +62,18 @@ CommandlineOptions *parse_commandline_arguments(int argc, char *argv[]) {
 			} else if (strcmp(argv[i], "-c") == 0) {
 				// compile to object file
 				options->link = false;
+			} else if (strlen(argv[i]) >= 2 && argv[i][1] == 'I') {
+				// add library path
+				if (strlen(argv[i] + 2) > 0) {
+					log_debug("adding library path '%s'\n", to_absolute_path(argv[i] + 2));
+					arraylist_add(options->library_paths, to_absolute_path(argv[i] + 2));
+					// i++;
+				} else {
+					log_error("no library path specified\n");
+					log_error("type 'lvc -h' for help\n");
+					options_free(options);
+					exit(1);
+				}
 			} else if (strcmp(argv[i], "-shared") == 0) {
 				// compile to shared library
 				options->is_shared_library = true;

--- a/src/util/options.c
+++ b/src/util/options.c
@@ -47,7 +47,7 @@ CommandlineOptions *parse_commandline_arguments(int argc, char *argv[]) {
 			} else if (strcmp(argv[i], "-o") == 0) {
 				// output file name
 				if (i + 1 < argc) {
-					options->output_file_name = argv[i + 1];
+					options->output_file_name = strdup(argv[i + 1]);
 					i++;
 				} else {
 					log_error("no output file specified\n");

--- a/test.py
+++ b/test.py
@@ -61,7 +61,7 @@ os.chdir(test_dir)
 
 for test in test_files:
 	# compile test
-	compile_proc = subprocess.Popen(['../bin/lvc', test], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+	compile_proc = subprocess.Popen(['../bin/debug/lvc', test], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
 	stdout, stderr = compile_proc.communicate()
 

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,7 @@ echo "--------------- [BUILDING] ---------------"
 echo ""
 
 # build the project
-make build
+make debug
 
 cd ./tests
 
@@ -22,7 +22,7 @@ if [ $# -eq 0 ]; then
 		echo ""
 
 		# compile the test file with the previously built project binary
-		../bin/lvc -S "$file"
+		../bin/debug/lvc -S "$file"
 
 		# execute the generated binary file
 		./a.out
@@ -39,7 +39,7 @@ else
 		echo ""
 
 		# compile the test file with the previously built project binary
-		../bin/lvc -S test${test}.lv
+		../bin/debug/lvc -S test${test}.lv
 
 		# execute the generated binary file
 		./a.out

--- a/test_euler.sh
+++ b/test_euler.sh
@@ -5,7 +5,7 @@ echo "--------------- [BUILDING] ---------------"
 echo ""
 
 # build the project
-make build
+make debug
 
 cd ./tests/euler
 
@@ -22,7 +22,7 @@ if [ $# -eq 0 ]; then
 		echo ""
 
 		# compile the test file with the previously built project binary
-		../../bin/lvc -S "$file" "../../lib/math.lv" "../../lib/io.lv" "../../lib/util.lv"
+		../../bin/debug/lvc -S "$file" -I../../lib
 
 		# execute the generated binary file
 		./a.out
@@ -43,7 +43,7 @@ else
 		echo ""
 
 		# compile the test file with the previously built project binary
-		../../bin/lvc -S problem${test}.lvs "../../lib/math.lv" "../../lib/io.lv" "../../lib/util.lv"
+		../../bin/debug/lvc -S problem${test}.lvs -I../../lib
 
 		# execute the generated binary file
 		./a.out

--- a/tests/euler/problem1.lvs
+++ b/tests/euler/problem1.lvs
@@ -1,4 +1,4 @@
-from io import print_number;
+import io::print_number;
 
 function main(): int {
 	var index: int = 0;

--- a/tests/euler/problem2.lvs
+++ b/tests/euler/problem2.lvs
@@ -1,4 +1,4 @@
-from io import print_number;
+import io::print_number;
 
 function fib(n: int): int {
 	if (n <= 1)

--- a/tests/euler/problem3.lvs
+++ b/tests/euler/problem3.lvs
@@ -1,6 +1,6 @@
-from io import print_number;
-from math import sqrt;
-from util import isPrime;
+import io::print_number;
+import math::sqrt;
+import util::isPrime;
 
 function main(): int {
 	var index: long = 3;

--- a/tests/euler/problem7.lvs
+++ b/tests/euler/problem7.lvs
@@ -1,6 +1,5 @@
-from io import print_number;
-from math import sqrt;
-from util import isPrime;
+import io::print_number;
+import util::isPrime;
 
 function main(): int {
 	// get 10001th prime


### PR DESCRIPTION
Syntax of the new import declarations:
`import <package>::<type>;`
or
`import <package>::{ <type>, <type>, ... };`
To import all types from a package use:
 `import <package>::*;`

closes #18 